### PR TITLE
Refactor: remove FastWriter and rename NormalWriter

### DIFF
--- a/docs/common.md
+++ b/docs/common.md
@@ -26,7 +26,7 @@ set_custom_style('bold_style', bold_style)
     you can use `#!python ws['A1'] = (123, 'bold_style')` or
     `#!python ws['A1'] = (123, bold_style)`.
 
-## `column_to_index`
+## column_to_index
 
 Converts an Excel column name to an index, e.g., 'A' -> 1.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -44,11 +44,7 @@ if __name__ == '__main__':
 
 ### Write excel via StreamWriter
 
-!!! warning "Warning"
-    Please note that the usage of StreamWriter, such as `FastWriter` and
-    `NormalWriter`, may have changed in recent versions (currently v0.0.7).
-
-You can also using the `FastWriter` or `NormalWriter` which was the
+You can also using the `StreamWriter` which was the
 subclass of `Workbook` to write excel row by row, see the following steps:
 
 1. Create a class for your `style` registed like `StyleCollections`
@@ -62,17 +58,16 @@ in the example.
         and inherit it from your `Writer` class.
 
 2. Create a class for your excel creation implementation and inherit
-`NormalWriter` or `FastWriter` and `StyleCollections`.
+`StreamWriter` and `StyleCollections`.
 
 3. Implement your data writing logic in `def _create_body()` and
 `def _create_single_header()`(The latter is not necessary)
 
-!!! example "NormalWriter"
+!!! example "StreamWriter"
 
     ```python
     from openpyxl.styles import Side
-    from pyfastexcel import CustomStyle
-    from pyfastexcel.driver import FastWriter, NormalWriter
+    from pyfastexcel import CustomStyle, StreamWriter
 
 
     def prepare_example_data(rows: int = 1000, cols: int = 10) -> list[dict[str, str]]:
@@ -128,7 +123,7 @@ in the example.
         )
 
 
-    class PyExcelizeNormalExample(NormalWriter, StyleCollections):
+    class PyFastExcelStreamExample(StreamWriter, StyleCollections):
 
         def create_excel(self) -> bytes:
             self._set_header()
@@ -166,69 +161,8 @@ in the example.
 
     if __name__ == '__main__':
         data = prepare_example_data(653, 90)
-        normal_writer = PyExcelizeFastExample(data)
-        excel_normal = normal_writer.create_excel()
-        file_path = 'pyexample_normal.xlsx'
-        normal_writer.save('pyexample_normal.xlsx')
-    ```
-
-The example of FastWriter now supports index assignment. Please see
-the last few lines of code in `_create_body()` for reference.
-
-!!! example "FastWriter"
-    ```python
-    from pyfastexcel.driver import FastWriter
-
-
-    class PyExcelizeFastExample(FastWriter, StyleCollections):
-
-        def create_excel(self) -> bytes:
-            self._set_header()
-            self._create_style()
-            self.set_file_props('Creator', 'Hello')
-            self._create_single_header()
-            self._create_body()
-            return self.read_lib_and_create_excel()
-
-        def _set_header(self):
-            self.headers = list(self.data[0].keys())
-
-        def _create_single_header(self):
-            for h in self.headers:
-                self.row_append(h, style='green_fill_style')
-            self.create_row()
-
-        def _create_body(self) -> None:
-            for row in self.data:
-                for h in self.headers:
-                    if h[-1] in ('1', '3', '5', '7', '9'):
-                        self.row_append(row[h], style='black_fill_style')
-                    else:
-                        self.row_append(row[h], style='test_fill_style')
-                self.create_row()
-
-            self.switch_sheet('Sheet2')
-            for row in self.data:
-                for h in self.headers:
-                    if h[-1] in ('1', '3', '5', '7', '9'):
-                        self.row_append(row[h], style=self.green_fill_style)
-                    else:
-                        self.row_append(row[h], style='black_fill_style')
-                self.create_row()
-
-            # Assigning a value with a specific style
-            self.workbook['Sheet1']['A2'] = ('Hellow World', 'black_fill_style')
-
-            # Assigning a value without specifying a style (default style used)
-            self.workbook['Sheet1']['A3'] = 'I am A3'
-            self.workbook['Sheet1']['AB9'] = 'GOGOGO'
-
-
-    if __name__ == '__main__':
-        data = prepare_example_data(653, 90)
-        normal_writer = PyExcelizeFastExample(data)
-        excel_normal = normal_writer.create_excel()
-        file_path = 'pyexample_normal.xlsx'
-        normal_writer.save('pyexample_normal.xlsx')
-
+        stream_writer = PyFastExcelStreamExample(data)
+        excel_bytes = stream_writer.create_excel()
+        file_path = 'pyexample_stream.xlsx'
+        stream_writer.save(file_path)
     ```

--- a/docs/writer.md
+++ b/docs/writer.md
@@ -1,31 +1,17 @@
-# StreamWriter
+# Overview
 
-StreamWriter is a method for writing Excel row by row. `pyfastexcel` currently
-provides two StreamWriter options: `NormalWriter` and `FastWriter`.
+`StreamWriter` is a method for writing Excel row by row. `pyfastexcel`.
 
-!!! warning "Warning"
-    Please note that `NormalWriter` and `FastWriter` are currently not stable
-    for usage. We are planning to refactor them to improve readability and
-    usability.
+## StreamWriter
 
-!!! note "Differnce between `NormalWrtier` and `FastWriter`"
-    The main difference between `NormalWriter` and `FastWriter` is that
-    `NormalWriter` does not pre-allocate memory space for data, while
-    `FastWriter` does. When dealing with large datasets to write into
-    Excel, `FastWriter` offers faster performance. Another distinction
-    is that currently only `FastWriter` supports index assignment, as seen
-    in `Workbook`.
-
-## NormalWriter
-
-`NormalWriter` provides non-static memory space for data. Users do not need to
+`StreamWriter` provides non-static memory space for data. Users do not need to
 allocate the number of rows and columns needed. Instead, they can use `append`
-to add data to the last row of `NormalWriter`. Below are steps to demonstrate
-how to use `NormalWriter` to create an Excel file.
+to add data to the last row of `StreamWriter`. Below are steps to demonstrate
+how to use `StreamWriter` to create an Excel file.
 
 1. Prepare the data. By default, data should be structured as a list, such as
 `#!python list[dict[str, str]]`. However, there is no strict data structure
-requirement for `NormalWriter`. You can pass any type of data and implement
+requirement for `StreamWriter`. You can pass any type of data and implement
 your own row-by-row writing method.
 
     ```python title="Prepare Data"
@@ -46,7 +32,7 @@ your own row-by-row writing method.
 
 2. Create the style collections
 
-    ```python title="NormalWriter"
+    ```python title="Create Styles"
     from openpyxl_style_writer import CustomStyle
     from openpyxl.styles import Side
 
@@ -89,10 +75,10 @@ your own row-by-row writing method.
         )
     ```
 
-3. Create a class and inherit `NormalWriter` and `StyleCollections`:
+3. Create a class and inherit `StreamWriter` and `StyleCollections`:
 
-    ```python title="NormalWriter"
-    class PyExcelizeNormalExample(NormalWriter, StyleCollections):
+    ```python title="StreamWriter"
+    class PyFastExcelStreamExample(StreamWriter, StyleCollections):
 
         def create_excel(self) -> bytes:
             self._set_header()
@@ -127,145 +113,19 @@ your own row-by-row writing method.
                     else:
                         self.row_append(row[h], style='black_fill_style')
                 self.create_row()
+
+            # You can also assign the value via index
+            self.workbook['Sheet1']['A2'] = ('Hellow World', 'black_fill_style')
+            self.workbook['Sheet1']['A3'] = 'I am A3'
+            self.workbook['Sheet1']['AB9'] = 'qwer'
     ```
 
 4. Pass the data to initialize the Writer class and create the Excel:
 
     ```python title="Write Excel"
     data = prepare_example_data(653, 90)
-    normal_writer = PyExcelizeFastExample(data)
-    excel_normal = normal_writer.create_excel()
+    stream_writer = PyFastExcelStreamExample(data)
+    excel_bytes = stream_writer.create_excel()
     file_path = 'pyexample_normal.xlsx'
-    normal_writer.save('pyexample_normal.xlsx')
-    ```
-
-## FastWriter
-
-`FastWriter` should pre-allocate memory space for data. Users need to
-allocate the number of rows and columns needed. They have to use `append`
-to add data to the current last row of `FastWriter`. Below are steps
-to demonstrate how to use `FastWriter` to create an Excel file.
-
-1. Prepare the data. By default, data should be structured as a list, such as
-`#!python list[dict[str, str]]`. `FastWriter` utilizes this structured list to
-allocate memory space. Therefore, if you wish to input data with other structure
-, you need to override the `__init__` method of `FastWriter` and implement
-your own memory allocation logic.
-
-    ```python title="Prepare Data"
-    def prepare_example_data(rows: int = 1000, cols: int = 10) -> list[dict[str, str]]:
-        import random
-
-        random.seed(42)
-        headers = [f'Column_{i}' for i in range(cols)]
-        data = [[random.random() for _ in range(cols)] for _ in range(rows)]
-        records = []
-        for row in data:
-            record = {}
-            for header, value in zip(headers, row):
-                record[header] = str(round(value * 100, 2))
-            records.append(record)
-        return records
-    ```
-
-2. Create the style collections
-
-    ```python title="NormalWriter"
-    from openpyxl_style_writer import CustomStyle
-    from openpyxl.styles import Side
-
-
-    class StyleCollections:
-        black_fill_style = CustomStyle(
-            font_size='11',
-            font_bold=True,
-            font_color='F62B00',
-            fill_color='000000',
-        )
-        green_fill_style = CustomStyle(
-            font_size='29',
-            font_bold=False,
-            font_color='000000',
-            fill_color='375623',
-        )
-        test_fill_style = CustomStyle(
-            font_params={
-                'size': 20,
-                'bold': True,
-                'italic': True,
-                'color': '5e03fc',
-            },
-            fill_params={
-                'patternType': 'solid',
-                'fgColor': '375623',
-            },
-            border_params={
-                'left': Side(style='thin', color='e12aeb'),
-                'right': Side(style='thick', color='e12aeb'),
-                'top': Side(style=None, color='e12aeb'),
-                'bottom': Side(style='dashDot', color='e12aeb'),
-            },
-            ali_params={
-                'wrapText': True,
-                'shrinkToFit': True,
-            },
-            number_format='0.00%',
-        )
-    ```
-
-3. Create a class and inherit `FastWriter` and `StyleCollections`:
-
-    ```python title="FastWriter"
-    class PyExcelizeFastExample(FastWriter, StyleCollections):
-
-            def create_excel(self) -> bytes:
-                self._set_header()
-                self._create_style()
-                self.set_file_props('Creator', 'Hello')
-                self._create_single_header()
-                self._create_body()
-                return self.read_lib_and_create_excel()
-
-            def _set_header(self):
-                self.headers = list(self.data[0].keys())
-
-            def _create_single_header(self):
-                for h in self.headers:
-                    self.row_append(h, style='green_fill_style')
-                self.create_row()
-
-            def _create_body(self) -> None:
-                for row in self.data:
-                    for h in self.headers:
-                        if h[-1] in ('1', '3', '5', '7', '9'):
-                            self.row_append(row[h], style='black_fill_style')
-                        else:
-                            self.row_append(row[h], style='test_fill_style')
-                    self.create_row()
-
-                self.switch_sheet('Sheet2')
-                for row in self.data:
-                    for h in self.headers:
-                        if h[-1] in ('1', '3', '5', '7', '9'):
-                            self.row_append(row[h], style=self.green_fill_style)
-                        else:
-                            self.row_append(row[h], style='black_fill_style')
-                    self.create_row()
-
-                # Assigning a value with a specific style
-                self.workbook['Sheet1']['A2'] = ('Hellow World', 'black_fill_style')
-
-                # Assigning a value without specifying a style (default style used)
-                self.workbook['Sheet1']['A3'] = 'I am A3'
-                self.workbook['Sheet1']['AB9'] = 'GOGOGO'
-    ```
-
-4. Pass the data to initialize the Writer class and create the Excel:
-
-    ```python title="Write Excel"
-    data = prepare_example_data(653, 90)
-    normal_writer = PyExcelizeFastExample(data)
-    excel_normal = normal_writer.create_excel()
-    file_path = 'pyexample_normal.xlsx'
-    normal_writer.save('pyexample_normal.xlsx')
+    stream_writer.save('pyexample_normal.xlsx')
     ```

--- a/example.py
+++ b/example.py
@@ -4,7 +4,7 @@ import time
 
 from openpyxl.styles import Side
 
-from pyfastexcel import CustomStyle, FastWriter, NormalWriter, Workbook
+from pyfastexcel import CustomStyle, StreamWriter, Workbook
 from pyfastexcel.utils import set_custom_style
 
 
@@ -59,44 +59,7 @@ class StyleCollections:
     )
 
 
-class PyExcelizeFastExample(FastWriter, StyleCollections):
-    def create_excel(self) -> bytes:
-        self._set_header()
-        self._create_style()
-        self._create_body()
-        return self.read_lib_and_create_excel()
-
-    def _set_header(self):
-        self.headers = list(self.data[0].keys())
-        for h in self.headers:
-            self.row_append(h, style='black_fill_style')
-        self.set_cell_width(self.sheet, 3, 255)
-        self.set_cell_height(self.sheet, 4, 123)
-        self.create_row()
-
-    def _create_body(self) -> None:
-        for row in self.data:
-            for h in self.headers:
-                if h[-1] in ('1', '3', '5', '7', '9'):
-                    self.row_append(row[h], style='black_fill_style')
-                else:
-                    self.row_append(row[h], style='test_fill_style')
-            self.create_row()
-
-        self.create_sheet('Sheet2')
-        for row in self.data:
-            for h in self.headers:
-                if h[-1] in ('1', '3', '5', '7', '9'):
-                    self.row_append(row[h], style='test_fill_style')
-                else:
-                    self.row_append(row[h], style='black_fill_style')
-            self.create_row()
-        self.workbook['Sheet1']['A2'] = ('Hellow World', 'black_fill_style')
-        self.workbook['Sheet1']['A3'] = 'I am A3'
-        self.workbook['Sheet1']['AB9'] = 'qwer'
-
-
-class PyExcelizeNormalExample(NormalWriter, StyleCollections):
+class PyFastExcelStreamExample(StreamWriter, StyleCollections):
     def create_excel(self) -> bytes:
         self._set_header()
         self._create_style()
@@ -142,23 +105,19 @@ class PyExcelizeNormalExample(NormalWriter, StyleCollections):
         self.set_cell_width(self.sheet, 'A', 255)
         self.set_cell_height(self.sheet, 4, 123)
         self.set_merge_cell(self.sheet, 'A2', 'A6')
+        self.workbook['Sheet1']['A2'] = ('Hellow World', 'black_fill_style')
+        self.workbook['Sheet1']['A3'] = 'I am A3'
+        self.workbook['Sheet1']['AB9'] = 'qwer'
 
 
 if __name__ == '__main__':
     data = prepare_example_data(6, 9)
 
-    # Fast Writer
-    fast_start_time = time.perf_counter()
-    pyfast_example = PyExcelizeFastExample(data)
-    excel_fast = pyfast_example.create_excel()
-    fast_end_time = time.perf_counter()
-    print('PYExcelizeFastDriver time: ', fast_end_time - fast_start_time)
-
-    # Normal Writer
+    # StreamWriter
     normal_start_time = time.perf_counter()
-    excel_normal = PyExcelizeNormalExample(data).create_excel()
+    excel_normal = PyFastExcelStreamExample(data).create_excel()
     notmal_end_time = time.perf_counter()
-    print('PYExcelizeNormalDriver time: ', notmal_end_time - normal_start_time)
+    print('PyFastExcelStreamWriter time: ', notmal_end_time - normal_start_time)
 
     # Workbook
     wb = Workbook()
@@ -187,14 +146,12 @@ if __name__ == '__main__':
     wb.read_lib_and_create_excel()
 
     # File path to save
-    file_path = 'pyexample_fast.xlsx'
-    file_path2 = 'pyexample_normal.xlsx'
-    file_path3 = 'pyexample_workbook.xlsx'
+    file_path1 = 'pyexample_stream.xlsx'
+    file_path2 = 'pyexample_workbook.xlsx'
 
     # Save to the xlsx with save function of Workbook
-    pyfast_example.save(file_path)
-    wb.save(file_path3)
+    wb.save(file_path2)
 
     # Save to the xlsx by the bytes return from create_excel()
-    with open(file_path2, 'wb') as file:
+    with open(file_path1, 'wb') as file:
         file.write(excel_normal)

--- a/pyfastexcel/__init__.py
+++ b/pyfastexcel/__init__.py
@@ -1,11 +1,10 @@
 from openpyxl_style_writer import CustomStyle, DefaultStyle
 
-from pyfastexcel.writer import FastWriter, NormalWriter, Workbook
+from pyfastexcel.writer import StreamWriter, Workbook
 
 __all__ = [
     'Workbook',
-    'FastWriter',
-    'NormalWriter',
+    'StreamWriter',
     # Temporary link the CustomStyle from openpyxl_style_writer for
     # convinent usage.
     'CustomStyle',

--- a/pyfastexcel/driver.py
+++ b/pyfastexcel/driver.py
@@ -105,7 +105,7 @@ class ExcelDriver:
         current sheet, and style mappings.
         """
         self.workbook = {
-            'Sheet1': WorkSheet(index_supported=True) if self.INDEX_SUPPORTED else WorkSheet(),
+            'Sheet1': WorkSheet(),
         }
         self.file_props = self._get_default_file_props()
         self.sheet = 'Sheet1'
@@ -358,8 +358,6 @@ class WorkSheet:
         merge_cells (list): A list of merged cell ranges.
         width (dict): A dictionary mapping column indices to column widths.
         height (dict): A dictionary mapping row indices to row heights.
-        index_supported (bool): A flag indicating whether index-based
-            access is supported.
 
     Methods:
         _transfer_to_dict():
@@ -391,7 +389,7 @@ class WorkSheet:
             index. Raises TypeError if index_supported is False.
     """
 
-    def __init__(self, index_supported: bool = False):
+    def __init__(self):
         """
         Initializes a WorkSheet instance.
 
@@ -405,7 +403,6 @@ class WorkSheet:
         self.merge_cells = []
         self.width = {}
         self.height = {}
-        self.index_supported = index_supported
 
     def cell(
         self,
@@ -454,9 +451,6 @@ class WorkSheet:
             TypeError: If target type is invalid.
             ValueError: If style is not registered.
         """
-        if self.index_supported is False:
-            raise IndexError('Index is not supported in this Writer.')
-
         if isinstance(style, str):
             if ExcelDriver.REGISTERED_STYLES.get(style) is None:
                 raise ValueError(
@@ -648,28 +642,22 @@ class WorkSheet:
         return value
 
     def __getitem__(self, key: str | slice) -> tuple | list[tuple]:
-        if self.index_supported:
-            if isinstance(key, slice):
-                return self._get_cell_by_slice(key)
-            elif isinstance(key, int):
-                return self.data[key]
-            elif isinstance(key, str):
-                return self._get_cell_by_location(key)
-        else:
-            raise IndexError('Index is not supported in this Writer.')
+        if isinstance(key, slice):
+            return self._get_cell_by_slice(key)
+        elif isinstance(key, int):
+            return self.data[key]
+        elif isinstance(key, str):
+            return self._get_cell_by_location(key)
 
     def __setitem__(self, key: str | slice | int, value: Any) -> None:
-        if self.index_supported:
-            if isinstance(key, slice):
-                self._set_cell_by_slice(key, value)
-            elif isinstance(key, int):
-                self._set_row_by_index(key, value)
-            elif isinstance(key, str):
-                self._set_cell_by_location(key, value)
-            else:
-                raise TypeError('Key should be a string or slice.')
+        if isinstance(key, slice):
+            self._set_cell_by_slice(key, value)
+        elif isinstance(key, int):
+            self._set_row_by_index(key, value)
+        elif isinstance(key, str):
+            self._set_cell_by_location(key, value)
         else:
-            raise IndexError('Index is not supported in this Writer.')
+            raise TypeError('Key should be a string or slice.')
 
     def _get_cell_by_slice(self, cell_slice: slice) -> list[tuple]:
         start_row = extract_numeric_part(cell_slice.start)

--- a/pyfastexcel/writer.py
+++ b/pyfastexcel/writer.py
@@ -33,8 +33,6 @@ class Workbook(ExcelDriver):
             Sets a merge cell range in the specified sheet.
     """
 
-    INDEX_SUPPORTED = True
-
     def remove_sheet(self, sheet: str) -> None:
         """
         Removes a sheet from the Excel data.
@@ -59,9 +57,7 @@ class Workbook(ExcelDriver):
         """
         if self.workbook.get(sheet_name) is not None:
             raise ValueError(f'Sheet {sheet_name} already exists.')
-        self.workbook[sheet_name] = (
-            WorkSheet(index_supported=True) if self.INDEX_SUPPORTED else WorkSheet()
-        )
+        self.workbook[sheet_name] = WorkSheet()
         self.sheet = sheet_name
         self._sheet_list = tuple([x for x in self._sheet_list] + [sheet_name])
 
@@ -107,125 +103,21 @@ class Workbook(ExcelDriver):
         self.workbook[sheet].set_merge_cell(top_left_cell, bottom_right_cell)
 
 
-class FastWriter(Workbook):
-    """
-    A class for fast writing data to Excel files with custom styles.
-
-    Attributes:
-        INDEX_SUPPORTED (bool): Indicates whether the writer supports using
-            index to access worksheet.
-        _row_list (list[list[Union[str, Tuple[str, str]]]]): A list of rows to
-        be written to the Excel file.
-        data (list[dict[str, str]]): The data to be written to the Excel file.
-
-    Methods:
-        __init__(data: list[dict[str, str]]): Initializes the FastWriter.
-        row_append(value: str, style: str, row_idx: int, col_idx: int): Appends
-            a value to a specific row and column.
-        _pop_none_from_row_list(idx: int) -> None: Removes None values from
-            the row list.
-        apply_to_header(idx: int = 0): Applies the header row to the Excel data.
-            create_row(idx): Creates a row in the Excel data.
-    """
-
-    INDEX_SUPPORTED = True
-
-    def __init__(self, data: list[dict[str, str]]):
-        """
-        Initializes the FastWriter.
-
-        Args:
-            data (list[dict[str, str]]): The data to be written to the
-            Excel file.
-        """
-        super().__init__()
-        # The data is list[dict[str, str]] as default, if your data is other dtype
-        # You should override the __init___ method to allocate correct space for _row_list
-        self.max_rows = len(data) + 1
-        self.max_cols = len(data[0]) + 1
-        self._row_list = [[None] * (self.max_cols) for _ in range(self.max_rows)]
-        self._original_row_list = self._row_list.copy()
-        self.workbook[self.sheet].data = self._original_row_list.copy()
-        self.data = data
-        # The row and col index for streaming row_append method
-        self.current_row = 0
-        self.current_col = 0
-
-    def row_append(self, value: Any, style: str | CustomStyle = 'DEFAULT_STYLE'):
-        """
-        Appends a value to a specific row and column.
-
-        Args:
-            value (Any): The value to be appended.
-            style (str): The style of the value.
-        """
-        if isinstance(style, CustomStyle):
-            if self._STYLE_NAME_MAP.get(style) is None:
-                validate_and_register_style(style)
-            style = self._STYLE_NAME_MAP[style]
-        value = validate_and_format_value(value, set_default_style=False)
-        self._row_list[self.current_row][self.current_col] = (value, style)
-        self.current_col += 1
-
-    def create_sheet(self, sheet_name: str) -> None:
-        super().create_sheet(sheet_name)
-        self.workbook[self.sheet].data = self._original_row_list.copy()
-        self.reset_row_list()
-
-    def switch_sheet(self, sheet_name: str) -> None:
-        super().switch_sheet(sheet_name)
-        self.reset_row_list()
-
-    def reset_row_list(self):
-        self._row_list = self._original_row_list.copy()
-        self.current_row = 0
-
-    def _pop_none_from_row_list(self, idx: int) -> None:
-        """
-        Removes None values from the row list.
-
-        Args:
-            idx (int): The index of the row.
-        """
-        for i in range(len(self._row_list[idx]) - 1, 0, -1):
-            if self._row_list[idx][i] is None:
-                self._row_list[idx].pop()
-            else:
-                break
-
-    def create_row(self):
-        """
-        Creates a row in the Excel data.
-        """
-        self._pop_none_from_row_list(self.current_row)
-        self.workbook[self.sheet].data.append(
-            self._row_list[self.current_row].copy(),
-        )
-
-        # Row + 1, Column reset
-        self.current_row += 1
-        self.current_col = 0
-
-
-class NormalWriter(Workbook):
+class StreamWriter(Workbook):
     """
     A class for writing data to Excel files with or without custom styles.
 
     Attributes:
-        INDEX_SUPPORTED (bool): Indicates whether the writer supports using
-            index to access worksheet.
         _row_list (list[Tuple[str, str | CustomStyle]]): A list of tuples
             representing rows with values and styles.
         data (list[dict[str, str]]): The data to be written to the Excel file.
 
     Methods:
-        __init__(data: list[dict[str, str]]): Initializes the NormalWriter.
+        __init__(data: list[dict[str, str]]): Initializes the StreamWriter.
         row_append(value: str, style: str | CustomStyle): Appends a value to
             the row list.
         create_row(is_header: bool = False): Creates a row in the Excel data.
     """
-
-    INDEX_SUPPORTED = False
 
     def __init__(self, data: list[dict[str, str]]):
         """


### PR DESCRIPTION
1. Remove FastWriter

2. Rename NormalWriter to StreamWriter

3. Remove INDEX_SUPPORT attributes. All Workbook and Writer can use index assignment not.