### PR TITLE
Fix pivot tables for large streamed data ranges

### DIFF
--- a/pyfastexcel/core/writer.go
+++ b/pyfastexcel/core/writer.go
@@ -114,10 +114,14 @@ func (ew *ExcelWriter) writeExcel() string {
 			fmt.Println(err)
 		}
 
-		// Create Pivot Table. It should Create after the data is written
-		for _, pivot := range pivotTableList {
-			ew.createPivotTable(pivot)
-		}
+	}
+
+	// Create pivot tables after every sheet has been written and flushed. Large
+	// streamed worksheets can spill to temp files; seed the source header row in
+	// memory so excelize can validate PivotTableOptions.DataRange.
+	for _, pivot := range pivotTableList {
+		ew.seedPivotSourceHeaders(pivot)
+		ew.createPivotTable(pivot)
 	}
 
 	// Save data in buffer and encode binary data to base64
@@ -126,6 +130,73 @@ func (ew *ExcelWriter) writeExcel() string {
 	encodedString := base64.StdEncoding.EncodeToString(byteResults)
 
 	return encodedString
+}
+
+func getCellScalarValue(item interface{}) interface{} {
+	if cell, ok := item.([]interface{}); ok && len(cell) > 0 {
+		return cell[0]
+	}
+	return item
+}
+
+func (ew *ExcelWriter) seedPivotSourceHeaders(pivotData []interface{}) {
+	for _, pivot := range pivotData {
+		pivotMap := pivot.(map[string]interface{})
+		dataRange, ok := pivotMap["DataRange"].(string)
+		if !ok || !strings.Contains(dataRange, "!") {
+			continue
+		}
+
+		rangeParts := strings.SplitN(dataRange, "!", 2)
+		sheetName := strings.Trim(rangeParts[0], "'")
+		sourceRange := strings.ReplaceAll(rangeParts[1], "$", "")
+		cellRefs := strings.SplitN(sourceRange, ":", 2)
+		if len(cellRefs) != 2 {
+			continue
+		}
+
+		startCol, startRow, err := excelize.CellNameToCoordinates(cellRefs[0])
+		if err != nil {
+			continue
+		}
+		endCol, endRow, err := excelize.CellNameToCoordinates(cellRefs[1])
+		if err != nil {
+			continue
+		}
+		if endCol < startCol {
+			startCol, endCol = endCol, startCol
+		}
+		if endRow < startRow {
+			startRow = endRow
+		}
+
+		sheetData, ok := ew.Content[sheetName].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		dataRows, ok := sheetData["Data"].([]interface{})
+		if !ok || len(dataRows) < startRow {
+			continue
+		}
+		headerRow, ok := dataRows[startRow-1].([]interface{})
+		if !ok {
+			continue
+		}
+
+		for col := startCol; col <= endCol; col++ {
+			headerIndex := col - startCol
+			if headerIndex >= len(headerRow) {
+				continue
+			}
+			cell, err := excelize.CoordinatesToCellName(col, startRow)
+			if err != nil {
+				continue
+			}
+			if err := ew.File.SetCellValue(sheetName, cell, getCellScalarValue(headerRow[headerIndex])); err != nil {
+				fmt.Println(err)
+			}
+		}
+	}
 }
 
 // streamWriter writes content to different sheets in the Excel file based on provided data.

--- a/pyfastexcel/core/writer_test.go
+++ b/pyfastexcel/core/writer_test.go
@@ -1,10 +1,15 @@
 package core
 
 import (
+	"archive/zip"
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/xuri/excelize/v2"
 )
 
 var data map[string]interface{}
@@ -406,6 +411,146 @@ func TestWriteExcel2(t *testing.T) {
 		t.Error("Encoded Excel data is empty")
 	}
 
+}
+
+func TestWriteExcelCreatesPivotTableForLargeStreamedDataRange(t *testing.T) {
+	const rowCount = 2600
+	payload := strings.Repeat("x", 7000)
+	sheetRows := make([]interface{}, 0, rowCount+1)
+	sheetRows = append(sheetRows, []interface{}{"DEPT_NO", "AMOUNT", "PAYLOAD"})
+	for rowIndex := 0; rowIndex < rowCount; rowIndex++ {
+		sheetRows = append(
+			sheetRows,
+			[]interface{}{fmt.Sprintf("D%04d", rowIndex%10), rowIndex, payload},
+		)
+	}
+
+	pivotTable := map[string]interface{}{
+		"DataRange":       fmt.Sprintf("Sheet1!A1:C%d", rowCount+1),
+		"PivotTableRange": "Pivot!A3:C20",
+		"Rows": []interface{}{
+			map[string]interface{}{"Data": "DEPT_NO", "Name": "Dept No"},
+		},
+		"Filter":  []interface{}{},
+		"Columns": []interface{}{},
+		"Data": []interface{}{
+			map[string]interface{}{"Data": "AMOUNT", "Name": "Amount", "Subtotal": "Sum"},
+		},
+		"RowGrandTotals": true,
+		"ColGrandTotals": true,
+		"ShowDrill":      true,
+		"ShowRowHeaders": true,
+		"ShowColHeaders": true,
+		"ShowLastColumn": false,
+		"ClassicLayout":  true,
+	}
+
+	file := excelize.NewFile()
+	defer func() {
+		if err := file.Close(); err != nil {
+			fmt.Println(err)
+		}
+	}()
+	writer := ExcelWriter{
+		File:       file,
+		StyleMap:   map[string]interface{}{},
+		FileProps:  newFileProps(),
+		Protection: map[string]interface{}{},
+		SheetOrder: []interface{}{"Sheet1", "Pivot"},
+		Content: map[string]interface{}{
+			"Sheet1": newStreamWriterSheet(sheetRows, []interface{}{pivotTable}),
+			"Pivot":  newStreamWriterSheet([]interface{}{}, []interface{}{}),
+		},
+	}
+
+	decodedExcel, err := base64.StdEncoding.DecodeString(writer.writeExcel())
+	if err != nil {
+		t.Fatalf("Failed to decode encoded Excel data: %v", err)
+	}
+
+	archive, err := zip.NewReader(bytes.NewReader(decodedExcel), int64(len(decodedExcel)))
+	if err != nil {
+		t.Fatalf("Failed to read generated Excel archive: %v", err)
+	}
+
+	var pivotTableCount int
+	var pivotCacheCount int
+	var cacheDefinition string
+	for _, file := range archive.File {
+		switch {
+		case strings.HasPrefix(file.Name, "xl/pivotTables/pivotTable"):
+			pivotTableCount++
+		case strings.HasPrefix(file.Name, "xl/pivotCache/pivotCacheDefinition"):
+			pivotCacheCount++
+			cacheDefinition = readZipFile(t, file)
+		}
+	}
+
+	if pivotTableCount != 1 {
+		t.Fatalf("Expected 1 pivot table, got %d", pivotTableCount)
+	}
+	if pivotCacheCount != 1 {
+		t.Fatalf("Expected 1 pivot cache definition, got %d", pivotCacheCount)
+	}
+	if !strings.Contains(cacheDefinition, `sheet="Sheet1"`) {
+		t.Fatalf("Expected pivot cache source sheet to be Sheet1: %s", cacheDefinition)
+	}
+	expectedRef := fmt.Sprintf(`ref="A1:C%d"`, rowCount+1)
+	if !strings.Contains(cacheDefinition, expectedRef) {
+		t.Fatalf("Expected pivot cache source ref %s: %s", expectedRef, cacheDefinition)
+	}
+}
+
+func newStreamWriterSheet(dataRows []interface{}, pivotTables []interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"Data":           dataRows,
+		"Width":          map[string]interface{}{},
+		"Height":         map[string]interface{}{},
+		"MergeCells":     []interface{}{},
+		"AutoFilter":     []interface{}{},
+		"Panes":          map[string]interface{}{},
+		"DataValidation": []interface{}{},
+		"Comment":        []interface{}{},
+		"NoStyle":        true,
+		"Table":          []interface{}{},
+		"Chart":          []interface{}{},
+		"PivotTable":     pivotTables,
+		"SheetVisible":   true,
+		"WriterEngine":   "StreamWriter",
+	}
+}
+
+func newFileProps() map[string]interface{} {
+	return map[string]interface{}{
+		"Title":          "Test Excel File",
+		"Creator":        "Test User",
+		"Category":       "Test Category",
+		"ContentStatus":  "Draft",
+		"Description":    "Test Description",
+		"Keywords":       "Test Keywords",
+		"Language":       "en-US",
+		"LastModifiedBy": "Test User",
+		"Revision":       "1",
+		"Subject":        "Test Subject",
+		"Version":        "1.0",
+		"Identifier":     "",
+		"Created":        "",
+		"Modified":       "",
+	}
+}
+
+func readZipFile(t *testing.T, file *zip.File) string {
+	t.Helper()
+	reader, err := file.Open()
+	if err != nil {
+		t.Fatalf("Failed to open %s: %v", file.Name, err)
+	}
+	defer reader.Close()
+	buffer := new(bytes.Buffer)
+	if _, err := buffer.ReadFrom(reader); err != nil {
+		t.Fatalf("Failed to read %s: %v", file.Name, err)
+	}
+	return buffer.String()
 }
 
 func TestWriteExcelNormalWriter(t *testing.T) {


### PR DESCRIPTION
## Summary

- Defer pivot table creation until all worksheets have been written and flushed.
- Seed the source header row in the in-memory worksheet before creating pivot tables, so excelize can validate `PivotTableOptions.DataRange` after streamed worksheet data spills to a temp file.
- Add a regression test that writes a large streamed data range and verifies pivot table/cache parts are generated with the full source range.

## Problem

When a worksheet is written with excelize's StreamWriter and the streamed XML exceeds the in-memory chunk size, excelize spills data to a temp file. `AddPivotTable` validates `DataRange` by reading the source header row through `GetCellValue`. For spilled streamed worksheets, that header row may not be available through the in-memory worksheet buffer, so `AddPivotTable` returns:

```text
parameter 'DataRange' parsing error: parameter is invalid
```

This leaves generated workbooks without `xl/pivotTables/*` and `xl/pivotCache/*` parts, producing blank pivot sheets even though the raw data sheet exists.

## Fix

This change keeps collecting pivot table definitions while sheets are written, but creates pivot tables only after all sheets have been flushed. Before each pivot table is created, it uses the pivot `DataRange` to locate the source header row in pyfastexcel's original sheet data and seeds those header values into excelize's in-memory worksheet object.

The streamed worksheet XML remains the source written to the final XLSX. The seeded header row is only used so excelize can validate pivot fields and build the pivot cache.

## Tests

Ran with local Go by temporarily lowering the `go.mod` directive for the test environment only, then restoring it to `go 1.24`:

```text
GOTOOLCHAIN=local go test ./pyfastexcel/core -count=1
ok github.com/Zncl2222/pyfastexcel/pyfastexcel/core 0.249s
```